### PR TITLE
Proposal List Enhancements

### DIFF
--- a/components/Proposals.vue
+++ b/components/Proposals.vue
@@ -13,8 +13,12 @@
           </div>
           <div class="column is-one-fifths-desktop has-text-left-mobile has-text-right-desktop">
             <span class="tag" :class="{'is-success': proposal.status == 'ACTIVE', 'is-warning': proposal.status == 'DRAFT', 'is-link': proposal.status == 'PENDING', 'is-dark': proposal.status == 'CLOSED'}">{{ proposal.status }}</span>
-            <div class="is-size-7" v-if="proposal.status =='ACTIVE'">
-              <span v-for="result in proposal.vote_counts" :key="result.key" class="vote-result">
+            <span class="tag is-info" v-if="proposal.cycle">C{{ proposal.cycle }}</span>
+            <span class="tag is-success" v-if="proposal.state === 3">EXECUTED</span>
+            <span class="tag is-danger" v-if="proposal.state === 2">REJECTED</span>
+            <span class="tag is-success" v-if="proposal.state === 1">ACCEPTED</span>
+            <div class="is-size-7" v-if="(proposal.status ==='ACTIVE' || proposal.status ==='CLOSED')">
+               <span v-for="result in proposal.vote_counts" :key="result.key" class="vote-result">
                 <small><b :class="{'has-text-success': result.key === 1, 'has-text-danger': result.key === 2}">{{ voteTypes.find((vt) => vt.value == result.key).name }}: {{ result.value }}</b></small>
               </span>
             </div>

--- a/pages/proposals/index.vue
+++ b/pages/proposals/index.vue
@@ -55,9 +55,7 @@
       <template v-if="$dao.cycleConfig">
         <template v-if="currentCycle">
           <h5 v-if="filter === 'ACTIVE'">
-            Cycle {{ currentCycle }} ends {{
-              $moment($dao.cycleConfig.start_time + "Z").add($dao.proposalConfig.cycle_duration_sec, 'seconds').fromNow()
-            }}
+
           </h5>
           <h5 v-else-if="filter === 'PENDING'">
             Proposals for cycle {{ currentCycle + 1 }} starting {{
@@ -108,7 +106,7 @@ export default {
 
   data () {
     return {
-      filter: 'ALL',
+      filter: 'ACTIVE',
       statuses: [
         {
           id: 'ACTIVE',


### PR DESCRIPTION
#81
- Set Active to default filter
- Display Cycle Number next to Proposal Status
- Display Box for Rejected, Accepted and Executed Proposals
- Get rid of redundant Active text that tells you when proposal ends
- Show vote totals for all Active and Closed (my personal preference to see vote totals for all Closed proposals)